### PR TITLE
Fix issue with some rules throwing TypeError when Ember modules had mixins included

### DIFF
--- a/rules/alias-model-in-controller.js
+++ b/rules/alias-model-in-controller.js
@@ -20,7 +20,7 @@ module.exports = function(context) {
       if (!ember.isEmberController(node)) return;
 
       var callee = node.callee;
-      var properties = node.arguments[0].properties;
+      var properties = ember.getModuleProperties(node);
       var aliasPresent = false;
 
       properties.forEach(function(property) {

--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -61,7 +61,7 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (!ember.isEmberComponent(node)) return;
 
-      var properties = node.arguments[0].properties;
+      var properties = ember.getModuleProperties(node);
       var mappedProperties = properties.map(function(property) {
         return {
           node: property,

--- a/rules/order-in-models.js
+++ b/rules/order-in-models.js
@@ -73,7 +73,7 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (!ember.isDSModel(node)) return;
 
-      var properties = node.arguments[0].properties;
+      var properties = ember.getModuleProperties(node);
       var mappedProperties = properties.map(function(property) {
         return {
           node: property,

--- a/rules/query-params-on-top.js
+++ b/rules/query-params-on-top.js
@@ -18,7 +18,7 @@ module.exports = function(context) {
     CallExpression: function(node) {
       if (!ember.isEmberController(node)) return;
 
-      var properties = node.arguments[0].properties;
+      var properties = ember.getModuleProperties(node);
 
       var propKeys = properties.map(function(property) {
         return property.key.name;

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -9,7 +9,6 @@ module.exports = {
   // isEmberRoute: isEmberRoute,
 };
 
-
 // Private
 
 function isLocalModule(callee, element) {

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -5,6 +5,7 @@ module.exports = {
   isModule: isModule,
   isEmberComponent: isEmberComponent,
   isEmberController: isEmberController,
+  getModuleProperties: getModuleProperties,
   // isEmberRoute: isEmberRoute,
 };
 
@@ -42,6 +43,10 @@ function isEmberComponent(node) {
 
 function isEmberController(node) {
   return isModule(node, 'Controller');
+}
+
+function getModuleProperties(module) {
+  return utils.findNodes(module.arguments, 'ObjectExpression')[0];
 }
 
 // function isEmberRoute(node) {

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -9,6 +9,7 @@ module.exports = {
   // isEmberRoute: isEmberRoute,
 };
 
+
 // Private
 
 function isLocalModule(callee, element) {
@@ -46,7 +47,7 @@ function isEmberController(node) {
 }
 
 function getModuleProperties(module) {
-  return utils.findNodes(module.arguments, 'ObjectExpression')[0];
+  return utils.findNodes(module.arguments, 'ObjectExpression')[0].properties;
 }
 
 // function isEmberRoute(node) {

--- a/test/alias-model-in-controller.js
+++ b/test/alias-model-in-controller.js
@@ -34,7 +34,6 @@ eslintTester.run('alias-model-in-controller', rule, {
       code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model")});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     }
-
   ],
   invalid: [
     {
@@ -79,6 +78,5 @@ eslintTester.run('alias-model-in-controller', rule, {
         message: 'Alias your model',
       }],
     }
-
   ]
 });

--- a/test/alias-model-in-controller.js
+++ b/test/alias-model-in-controller.js
@@ -25,7 +25,16 @@ eslintTester.run('alias-model-in-controller', rule, {
     {
       code: 'export default Ember.Controller.extend({nail: Ember.computed.alias("model")});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Ember.Controller.extend(TestMixin, {nail: Ember.computed.alias("model")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {nail: Ember.computed.alias("model")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
     }
+
   ],
   invalid: [
     {
@@ -55,6 +64,21 @@ eslintTester.run('alias-model-in-controller', rule, {
       errors: [{
         message: 'Alias your model',
       }],
+    },
+    {
+      code: 'export default Ember.Controller.extend(TestMixin, {});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Alias your model',
+      }],
+    },
+    {
+      code: 'export default Ember.Controller.extend(TestMixin, TestMixin2, {});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Alias your model',
+      }],
     }
+
   ]
 });

--- a/test/order-in-components.js
+++ b/test/order-in-components.js
@@ -25,6 +25,14 @@ eslintTester.run('order-in-components', rule, {
     {
       code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend(TestMixin, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend(TestMixin, TestMixin2, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
     }
   ],
   invalid: [
@@ -44,6 +52,20 @@ eslintTester.run('order-in-components', rule, {
     },
     {
       code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), vehicle: alias("car"), role: "sloth", actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend(TestMixin, {levelOfHappiness: computed("attitude", "health", () => {\n}), vehicle: alias("car"), role: "sloth", actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend(TestMixin, TestMixin2, {levelOfHappiness: computed("attitude", "health", () => {\n}), vehicle: alias("car"), role: "sloth", actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',

--- a/test/order-in-models.js
+++ b/test/order-in-models.js
@@ -37,6 +37,14 @@ eslintTester.run('order-in-models', rule, {
     {
       code: 'export default DS.Model.extend({mood: computed("health", "hunger", function() {\n})});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default DS.Model.extend(TestMixin, {mood: computed("health", "hunger", function() {\n})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default DS.Model.extend(TestMixin, TestMixin2, {mood: computed("health", "hunger", function() {\n})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
     }
   ],
   invalid: [
@@ -84,6 +92,20 @@ eslintTester.run('order-in-models', rule, {
     },
     {
       code: 'export default DS.Model.extend({mood: computed("health", "hunger", function() {\n}), test: computed.alias("qwerty")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default DS.Model.extend(TestMixin, {mood: computed("health", "hunger", function() {\n}), test: computed.alias("qwerty")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default DS.Model.extend(TestMixin, TestMixin2, {mood: computed("health", "hunger", function() {\n}), test: computed.alias("qwerty")});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',

--- a/test/query-params-on-top.js
+++ b/test/query-params-on-top.js
@@ -46,10 +46,6 @@ eslintTester.run('query-params-on-top', rule, {
       code: 'export default Controller.extend(TestMixin, TestMixin2, {status: [], actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
-    {
-      code: 'export default Controller.extend({status: [], queryParams: ["status"]});',
-      parserOptions: {ecmaVersion: 6, sourceType: "module"},
-    },
   ],
   invalid: [
     {

--- a/test/query-params-on-top.js
+++ b/test/query-params-on-top.js
@@ -37,7 +37,19 @@ eslintTester.run('query-params-on-top', rule, {
     {
       code: 'export default Component.extend({status: attr("string"), queryParams: attr("string")});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
-    }
+    },
+    {
+      code: 'export default Controller.extend(TestMixin, {status: [], actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend(TestMixin, TestMixin2, {status: [], actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({status: [], queryParams: ["status"]});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
   ],
   invalid: [
     {
@@ -56,6 +68,20 @@ eslintTester.run('query-params-on-top', rule, {
     },
     {
       code: 'export default Controller.extend({status: [], queryParams: ["status"], actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Query params should always be on top',
+      }],
+    },
+    {
+      code: 'export default Controller.extend(TestMixin, {status: [], queryParams: ["status"], actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Query params should always be on top',
+      }],
+    },
+    {
+      code: 'export default Controller.extend(TestMixin, TestMixin2, {status: [], queryParams: ["status"], actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Query params should always be on top',


### PR DESCRIPTION
Fix for: https://github.com/netguru/eslint-plugin-netguru-ember/issues/1

- adds helper function that filters array of module nodes to the one which are type `ObjectExpression` and returns properties on the first one _(there should be just one in the filtered array)_ 
- use this helper method in all rules which previously didn't support modules with mixins
- add tests for mixins in modules