### PR TITLE
Extend order-in-components rule

### DIFF
--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -19,8 +19,12 @@ module.exports = function(context) {
     var value = property.value;
 
     return utils.isLiteral(value) ||
-      utils.isObjectExpression(value) ||
-      utils.isArrayExpression(value);
+      utils.isArrayExpression(value) ||
+      isDefaultObjectProp(property);
+  };
+
+  var isInjectedServiceProp = function(property) {
+    return ember.isInjectedServiceProp(property.value);
   };
 
   var isSingleLineFn = function(property) {
@@ -35,6 +39,10 @@ module.exports = function(context) {
     return property.key.name === 'actions' && utils.isObjectExpression(property.value);
   };
 
+  var isDefaultObjectProp = function(property) {
+    return property.key.name !== 'actions' && utils.isObjectExpression(property.value);
+  };
+
   var isCustomFunction = function(property) {
     return utils.isFunctionExpression(property.value);
   };
@@ -44,14 +52,16 @@ module.exports = function(context) {
 
     if (isDefaultProp(property)) {
       val = 10;
-    } else if (isSingleLineFn(property)) {
+    } else if (isInjectedServiceProp(property)) {
       val = 20;
-    } else if (isMultiLineFn(property)) {
+    } else if (isSingleLineFn(property)) {
       val = 30;
-    } else if (isActionsProp(property)) {
+    } else if (isMultiLineFn(property)) {
       val = 40;
-    } else if (isCustomFunction(property)) {
+    } else if (isActionsProp(property)) {
       val = 50;
+    } else if (isCustomFunction(property)) {
+      val = 60
     }
 
     return val;

--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -32,7 +32,13 @@ module.exports = function(context) {
   };
 
   var isMultiLineFn = function(property) {
-    return utils.isCallExpression(property.value) && utils.getSize(property.value) > 1;
+    return utils.isCallExpression(property.value) &&
+      utils.getSize(property.value) > 1 &&
+      ember.isObserverProp(property.value) === false;
+  };
+
+  var isObserverProp = function(property) {
+    return ember.isObserverProp(property.value);
   };
 
   var isActionsProp = function(property) {
@@ -44,7 +50,12 @@ module.exports = function(context) {
   };
 
   var isCustomFunction = function(property) {
-    return utils.isFunctionExpression(property.value);
+    return utils.isFunctionExpression(property.value) &&
+      ember.isComponentLifecycleHookName(property.key.name) === false;
+  };
+
+  var isLifecycleHook = function(property) {
+    return utils.isFunctionExpression(property.value) && ember.isComponentLifecycleHookName(property.key.name);
   };
 
   var getOrderValue = function(property) {
@@ -58,10 +69,14 @@ module.exports = function(context) {
       val = 30;
     } else if (isMultiLineFn(property)) {
       val = 40;
-    } else if (isActionsProp(property)) {
+    } else if (isObserverProp(property)) {
       val = 50;
+    } else if (isLifecycleHook(property)) {
+      val = 60;
+    } else if (isActionsProp(property)) {
+      val = 70;
     } else if (isCustomFunction(property)) {
-      val = 60
+      val = 80;
     }
 
     return val;

--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -35,6 +35,10 @@ module.exports = function(context) {
     return property.key.name === 'actions' && utils.isObjectExpression(property.value);
   };
 
+  var isCustomFunction = function(property) {
+    return utils.isFunctionExpression(property.value);
+  };
+
   var getOrderValue = function(property) {
     var val = null;
 
@@ -46,10 +50,12 @@ module.exports = function(context) {
       val = 30;
     } else if (isActionsProp(property)) {
       val = 40;
+    } else if (isCustomFunction(property)) {
+      val = 50;
     }
 
     return val;
-  }
+  };
 
   var findUnorderedProperty = function(arr) {
     var len = arr.length - 1;

--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -61,9 +61,9 @@ module.exports = function(context) {
   var getOrderValue = function(property) {
     var val = null;
 
-    if (isDefaultProp(property)) {
+    if (isInjectedServiceProp(property)) {
       val = 10;
-    } else if (isInjectedServiceProp(property)) {
+    } else if (isDefaultProp(property)) {
       val = 20;
     } else if (isSingleLineFn(property)) {
       val = 30;

--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -16,7 +16,11 @@ module.exports = function(context) {
   };
 
   var isDefaultProp = function(property) {
-    return utils.isLiteral(property.value);
+    var value = property.value;
+
+    return utils.isLiteral(value) ||
+      utils.isObjectExpression(value) ||
+      utils.isArrayExpression(value);
   };
 
   var isSingleLineFn = function(property) {

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -6,6 +6,8 @@ module.exports = {
   isEmberComponent: isEmberComponent,
   isEmberController: isEmberController,
   isInjectedServiceProp: isInjectedServiceProp,
+  isObserverProp: isObserverProp,
+  isComponentLifecycleHookName: isComponentLifecycleHookName,
   // isEmberRoute: isEmberRoute,
 };
 
@@ -22,6 +24,21 @@ function isEmberModule(callee, element, module) {
   return isLocalModule(memberExp, module) &&
     utils.isIdentifier(memberExp.property) &&
     memberExp.property.name === element;
+}
+
+function isPropOfType(node, type) {
+  var calleeNode = node.callee;
+
+  return utils.isCallExpression(node) &&
+    (
+      utils.isIdentifier(calleeNode) &&
+      calleeNode.name === type
+    ) ||
+    (
+      utils.isMemberExpression(calleeNode) &&
+      utils.isIdentifier(calleeNode.property) &&
+      calleeNode.property.name === type
+    );
 }
 
 // Public
@@ -46,19 +63,18 @@ function isEmberController(node) {
 }
 
 function isInjectedServiceProp(node) {
-  var name = 'service';
-  var calleeNode = node.callee;
+  return isPropOfType(node, 'service');
+}
 
-  return utils.isCallExpression(node) &&
-    (
-      utils.isIdentifier(calleeNode) &&
-      calleeNode.name === name
-    ) ||
-    (
-      utils.isMemberExpression(calleeNode) &&
-      utils.isIdentifier(calleeNode.property) &&
-      calleeNode.property.name === name
-    );
+function isObserverProp(node) {
+  return isPropOfType(node, 'observer');
+}
+
+function isComponentLifecycleHookName(name) {
+  var hooks = ['init', 'didReceiveAttrs', 'willRender', 'didInsertElement', 'didRender', 'didUpdateAttrs',
+    'willUpdate', 'didUpdate', 'willDestroyElement', 'willClearRender', 'didDestroyElement'];
+
+  return hooks.indexOf(name) !== -1;
 }
 
 // function isEmberRoute(node) {

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -5,6 +5,7 @@ module.exports = {
   isModule: isModule,
   isEmberComponent: isEmberComponent,
   isEmberController: isEmberController,
+  isInjectedServiceProp: isInjectedServiceProp,
   // isEmberRoute: isEmberRoute,
 };
 
@@ -42,6 +43,22 @@ function isEmberComponent(node) {
 
 function isEmberController(node) {
   return isModule(node, 'Controller');
+}
+
+function isInjectedServiceProp(node) {
+  var name = 'service';
+  var calleeNode = node.callee;
+
+  return utils.isCallExpression(node) &&
+    (
+      utils.isIdentifier(calleeNode) &&
+      calleeNode.name === name
+    ) ||
+    (
+      utils.isMemberExpression(calleeNode) &&
+      utils.isIdentifier(calleeNode.property) &&
+      calleeNode.property.name === name
+    );
 }
 
 // function isEmberRoute(node) {

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -5,6 +5,8 @@ module.exports = {
   isMemberExpression: isMemberExpression,
   isCallExpression: isCallExpression,
   isObjectExpression: isObjectExpression,
+  isArrayExpression: isArrayExpression,
+  isFunctionExpression: isFunctionExpression,
   isThisExpression: isThisExpression,
   getSize: getSize,
   parseCallee: parseCallee,
@@ -78,6 +80,26 @@ function isCallExpression(node) {
  */
 function isObjectExpression(node) {
     return node !== undefined && node.type === 'ObjectExpression';
+}
+
+/**
+ * Check whether or not a node is an ArrayExpression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an ArrayExpression.
+ */
+function isArrayExpression(node) {
+  return node !== undefined && node.type === 'ArrayExpression';
+}
+
+/**
+ * Check whether or not a node is an FunctionExpression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an FunctionExpression.
+ */
+function isFunctionExpression(node) {
+  return node !== undefined && node.type === 'FunctionExpression';
 }
 
 /**

--- a/test/order-in-components.js
+++ b/test/order-in-components.js
@@ -25,7 +25,27 @@ eslintTester.run('order-in-components', rule, {
     {
       code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
-    }
+    },
+    {
+      code: 'export default Component.extend({role: "sloth", abc: Ember.inject.service(), def: inject.service(), ghi: service(), levelOfHappiness: computed("attitude", "health", () => {\n})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({role: "sloth", abc: [], def: {}, ghi: service()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), abc: Ember.observer("aaaa", function () {\n}), def: observer("aaaa", function () {\n}), actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: observer("aaaa", () => {\n}), init: function () {\n}, actions: {}, customFunction() {\n}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: [], def: true, igh: service(), singleComp: alias("abc"), multiComp: computed(() => {\n}), obs: observer("aaa", function () {\n}), init: function () {\n}, actions: {}, customFunc: function() {\n}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
   ],
   invalid: [
     {
@@ -44,6 +64,55 @@ eslintTester.run('order-in-components', rule, {
     },
     {
       code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), vehicle: alias("car"), role: "sloth", actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({i18n: service(), abc: true});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({vehicle: alias("car"), i18n: service()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({levelOfHappiness: observer("attitude", "health", () => {\n}), vehicle: alias("car")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({levelOfHappiness: observer("attitude", "health", () => {\n}), aaa: computed("attitude", "health", () => {\n})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({init() {\n}, levelOfHappiness: observer("attitude", "health", () => {\n})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({actions: {}, init() {\n}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({customFunc() {\n}, actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',

--- a/test/order-in-components.js
+++ b/test/order-in-components.js
@@ -35,11 +35,11 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({role: "sloth", abc: Ember.inject.service(), def: inject.service(), ghi: service(), levelOfHappiness: computed("attitude", "health", () => {\n})});',
+      code: 'export default Component.extend({abc: Ember.inject.service(), def: inject.service(), ghi: service(), role: "sloth", levelOfHappiness: computed("attitude", "health", () => {\n})});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({role: "sloth", abc: [], def: {}, ghi: service()});',
+      code: 'export default Component.extend({role: "sloth", abc: [], def: {}, ghi: alias("def")});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
@@ -51,7 +51,7 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({abc: [], def: true, igh: service(), singleComp: alias("abc"), multiComp: computed(() => {\n}), obs: observer("aaa", () => {\n}), init() {\n}, actions: {}, customFunc() {\n}});',
+      code: 'export default Component.extend({igh: service(), abc: [], def: true, singleComp: alias("abc"), multiComp: computed(() => {\n}), obs: observer("aaa", () => {\n}), init() {\n}, actions: {}, customFunc() {\n}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
@@ -97,7 +97,7 @@ eslintTester.run('order-in-components', rule, {
       }],
     },
     {
-      code: 'export default Component.extend({i18n: service(), abc: true});',
+      code: 'export default Component.extend({abc: true, i18n: service()});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',

--- a/test/order-in-components.js
+++ b/test/order-in-components.js
@@ -27,6 +27,14 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
+      code: 'export default Component.extend(TestMixin, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend(TestMixin, TestMixin2, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
       code: 'export default Component.extend({role: "sloth", abc: Ember.inject.service(), def: inject.service(), ghi: service(), levelOfHappiness: computed("attitude", "health", () => {\n})});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
@@ -35,25 +43,22 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), abc: Ember.observer("aaaa", function () {\n}), def: observer("aaaa", function () {\n}), actions: {}});',
+      code: 'export default Component.extend({levelOfHappiness: computed("attitude", "health", () => {\n}), abc: Ember.observer("aaaa", () => {\n}), def: observer("aaaa", () => {\n}), actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({abc: observer("aaaa", () => {\n}), init: function () {\n}, actions: {}, customFunction() {\n}});',
+      code: 'export default Component.extend({abc: observer("aaaa", () => {\n}), init() {\n}, actions: {}, customFunction() {\n}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend({abc: [], def: true, igh: service(), singleComp: alias("abc"), multiComp: computed(() => {\n}), obs: observer("aaa", function () {\n}), init: function () {\n}, actions: {}, customFunc: function() {\n}});',
+      code: 'export default Component.extend({abc: [], def: true, igh: service(), singleComp: alias("abc"), multiComp: computed(() => {\n}), obs: observer("aaa", () => {\n}), init() {\n}, actions: {}, customFunc() {\n}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
-      code: 'export default Component.extend(TestMixin, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
+      code: 'export default Component.extend({init() {\n}, didReceiveAttrs() {\n}, willRender() {\n}, didInsertElement() {\n}, didRender() {\n}, didUpdateAttrs() {\n}, willUpdate() {\n}, didUpdate() {\n}, willDestroyElement() {\n}, willClearRender() {\n}, didDestroyElement() {\n}, actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
-    {
-      code: 'export default Component.extend(TestMixin, TestMixin2, {levelOfHappiness: computed("attitude", "health", () => {\n}), actions: {}});',
-      parserOptions: {ecmaVersion: 6, sourceType: "module"},
-    }
+
   ],
   invalid: [
     {


### PR DESCRIPTION
Addresses https://github.com/netguru/eslint-plugin-netguru-ember/issues/3 issue.
Add new prop types and change order:

1. services
2. default props (Literal, Arrays or Objects)
3. single line computed
4. multiline computed
5. observers
6. hooks
7. actions
8. custom / private method

Here is PR updating documentation: https://github.com/netguru/ember-styleguide/pull/9