### PR TITLE
Improve order-in-components

### DIFF
--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -28,13 +28,16 @@ module.exports = function(context) {
   };
 
   var isSingleLineFn = function(property) {
-    return utils.isCallExpression(property.value) && utils.getSize(property.value) === 1;
+    return utils.isCallExpression(property.value) &&
+      utils.getSize(property.value) === 1 &&
+      !utils.isCallWithFunctionExpression(property.value);
   };
 
   var isMultiLineFn = function(property) {
     return utils.isCallExpression(property.value) &&
       utils.getSize(property.value) > 1 &&
-      ember.isObserverProp(property.value) === false;
+      !ember.isObserverProp(property.value) &&
+      !utils.isCallWithFunctionExpression(property.value);
   };
 
   var isObserverProp = function(property) {
@@ -50,12 +53,14 @@ module.exports = function(context) {
   };
 
   var isCustomFunction = function(property) {
-    return utils.isFunctionExpression(property.value) &&
-      ember.isComponentLifecycleHookName(property.key.name) === false;
+    return (
+      utils.isFunctionExpression(property.value) || utils.isCallWithFunctionExpression(property.value)
+    ) && !ember.isComponentLifecycleHookName(property.key.name);
   };
 
   var isLifecycleHook = function(property) {
-    return utils.isFunctionExpression(property.value) && ember.isComponentLifecycleHookName(property.key.name);
+    return utils.isFunctionExpression(property.value) &&
+      ember.isComponentLifecycleHookName(property.key.name);
   };
 
   var getOrderValue = function(property) {

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -104,7 +104,7 @@ function isFunctionExpression(node) {
 }
 
 /**
- * Check wheter or not a node is a CallExpression that has a FunctionExpression
+ * Check whether or not a node is a CallExpression that has a FunctionExpression
  * as first argument, eg.:
  * tSomeAction: mysteriousFnc(function(){})
  *

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -7,6 +7,7 @@ module.exports = {
   isObjectExpression: isObjectExpression,
   isArrayExpression: isArrayExpression,
   isFunctionExpression: isFunctionExpression,
+  isCallWithFunctionExpression: isCallWithFunctionExpression,
   isThisExpression: isThisExpression,
   getSize: getSize,
   parseCallee: parseCallee,
@@ -100,6 +101,20 @@ function isArrayExpression(node) {
  */
 function isFunctionExpression(node) {
   return node !== undefined && node.type === 'FunctionExpression';
+}
+
+/**
+ * Check wheter or not a node is a CallExpression that has a FunctionExpression
+ * as first argument, eg.:
+ * tSomeAction: mysteriousFnc(function(){})
+ *
+ * @param  {[type]}  node [description]
+ * @return {Boolean}      [description]
+ */
+function isCallWithFunctionExpression(node) {
+  var firstArg = node.arguments ? node.arguments[0] : null;
+  return node !== undefined && isCallExpression(node) &&
+    firstArg && isFunctionExpression(firstArg);
 }
 
 /**

--- a/test/order-in-components.js
+++ b/test/order-in-components.js
@@ -58,7 +58,14 @@ eslintTester.run('order-in-components', rule, {
       code: 'export default Component.extend({init() {\n}, didReceiveAttrs() {\n}, willRender() {\n}, didInsertElement() {\n}, didRender() {\n}, didUpdateAttrs() {\n}, willUpdate() {\n}, didUpdate() {\n}, willDestroyElement() {\n}, willClearRender() {\n}, didDestroyElement() {\n}, actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
-
+    {
+      code: 'export default Component.extend({test: service(), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({test: service(), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n}), _anotherPrivateFnc() {\n}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    }
   ],
   invalid: [
     {
@@ -140,6 +147,13 @@ eslintTester.run('order-in-components', rule, {
     },
     {
       code: 'export default Component.extend({customFunc() {\n}, actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Check order of properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({tAction: test(function() {\n}), actions: {}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Check order of properties',


### PR DESCRIPTION
I checked `order-in-components` rule in more detail - testing different scenarios that we often encounter during development. I found that still there is a case where it's yelling about order, for example when we use `ember-concurrency` plugin.

I decided to improve this rule to treat this kind of code:
```
lorem: ipsum(function() {})
or
lorem: ipsum(function* () {})
```
as equal to custom function expressions, so that we can put it right below `actions` and everything is just fine.

I'm happy to hear your thoughts about this guys @Pasikonik @jniechcial 