### PR TITLE
Fix order in components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-netguru-ember",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Eslint plugin for Netguru Ember Style Guide",
   "main": "index.js",
   "directories": {

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -112,8 +112,9 @@ function isFunctionExpression(node) {
  * @return {Boolean}      [description]
  */
 function isCallWithFunctionExpression(node) {
-  var firstArg = node.arguments ? node.arguments[0] : null;
-  return node !== undefined && isCallExpression(node) &&
+  var callObj = isMemberExpression(node.callee) ? node.callee.object : node;
+  var firstArg = callObj.arguments ? callObj.arguments[0] : null;
+  return callObj !== undefined && isCallExpression(callObj) &&
     firstArg && isFunctionExpression(firstArg);
 }
 

--- a/test/order-in-components.js
+++ b/test/order-in-components.js
@@ -63,6 +63,10 @@ eslintTester.run('order-in-components', rule, {
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
     {
+      code: 'export default Component.extend({test: service(), test2: computed.equal("asd", "qwe"), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n}).restartable()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
       code: 'export default Component.extend({test: service(), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n}), _anotherPrivateFnc() {\n}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     }


### PR DESCRIPTION
Another thing came out,

when using:
```
tSomeAction: task(function* () {
}),
```
everything works fine, but with:
```
tSomeAction: task(function* () {
}).restartable(),
```
`order-in-components` rule doesn't pass.

This PR fixes described problem.