### PR TITLE
Fix order rule

### DIFF
--- a/rules/order-in-components.js
+++ b/rules/order-in-components.js
@@ -19,6 +19,7 @@ module.exports = function(context) {
     var value = property.value;
 
     return utils.isLiteral(value) ||
+      utils.isIdentifier(value) ||
       utils.isArrayExpression(value) ||
       isDefaultObjectProp(property);
   };

--- a/test/order-in-components.js
+++ b/test/order-in-components.js
@@ -69,6 +69,10 @@ eslintTester.run('order-in-components', rule, {
     {
       code: 'export default Component.extend({test: service(), didReceiveAttrs() {\n}, tSomeAction: task(function* (url) {\n}), _anotherPrivateFnc() {\n}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({classNameBindings: ["filterDateSelectClass"], content: [], currentMonthEndDate: null, currentMonthStartDate: null, optionValuePath: "value", optionLabelPath: "label", typeOfDate: null, action: K});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
     }
   ],
   invalid: [


### PR DESCRIPTION
As discussed with @netes identifier should also be treated as  default prop:
```
export default Component.extend({
  classNameBindings: ["filterDateSelectClass"],  
  optionValuePath: "value",
  action: K,
});
```
From now on `action: K` or any other assignment with identifier shouldn't cause order issues.