### PR TITLE
add support for multiple dynamic segments to routes-segments-snake-case rule

### DIFF
--- a/rules/routes-segments-snake-case.js
+++ b/rules/routes-segments-snake-case.js
@@ -26,13 +26,23 @@ module.exports = function(context) {
     return property.key.name === 'path' && property.value.value.indexOf(':') > -1;
   };
 
-  var getSegmentName = function(property) {
+  var getSegmentNames = function(property) {
     if (!isSegment(property)) return;
-    return property.value.value.split(':')[1];
+
+    var path = property.value.value;
+    var pattern = /:([a-zA-Z0-9-_]+)/g;
+    var segmentNames = [];
+    var execResult;
+
+    while (execResult = pattern.exec(path)) {
+      segmentNames.push(execResult[1]);
+    }
+
+    return segmentNames;
   };
 
-  var isSnakeCase = function(name) {
-    return snakeCase(name) === name;
+  var isNotSnakeCase = function(name) {
+    return snakeCase(name) !== name;
   };
 
   return {
@@ -43,8 +53,9 @@ module.exports = function(context) {
 
       if (routeOptions) {
         routeOptions.properties.forEach(function(property) {
-          var segmentName = getSegmentName(property);
-          if (segmentName && !isSnakeCase(segmentName)) {
+          var segmentNames = getSegmentNames(property);
+
+          if (segmentNames && segmentNames.filter(isNotSnakeCase).length) {
             report(property.value);
           }
         });

--- a/rules/routes-segments-snake-case.js
+++ b/rules/routes-segments-snake-case.js
@@ -29,16 +29,11 @@ module.exports = function(context) {
   var getSegmentNames = function(property) {
     if (!isSegment(property)) return;
 
-    var path = property.value.value;
-    var pattern = /:([a-zA-Z0-9-_]+)/g;
-    var segmentNames = [];
-    var execResult;
-
-    while (execResult = pattern.exec(path)) {
-      segmentNames.push(execResult[1]);
-    }
-
-    return segmentNames;
+    return property.value.value
+      .match(/:([a-zA-Z0-9-_]+)/g)
+      .map(function (segment) {
+        return segment.slice(1);
+      });
   };
 
   var isNotSnakeCase = function(name) {

--- a/test/routes-segments-snake-case.js
+++ b/test/routes-segments-snake-case.js
@@ -20,7 +20,13 @@ eslintTester.run('routes-segments-snake-case', rule, {
     'this.route("facebook-messages", { path: "fb-messages" });',
     'this.route("summary", { path: "/" });',
     'this.route("reset-password", function() {this.route("update");});',
-    'this.test()'
+    'this.test()',
+    'this.route("tree", { path: ":tree_id/:tree_child_id"});',
+    'this.route("tree", { path: "/test/:tree_id/:tree_child_id"});',
+    'this.route("tree", { path: "/test/:tree_id/test/:tree_child_id"});',
+    'this.route("tree", { path: "/test/:tree_id/test_test/:tree_child_id"});',
+    'this.route("tree", { path: "/test/:tree_id/test-test/:tree_child_id"});',
+    'this.route("tree", { path: "/test/:tree_id/testTest/:tree_child_id"});',
   ],
   invalid: [
     {
@@ -39,6 +45,20 @@ eslintTester.run('routes-segments-snake-case', rule, {
     },
     {
       code: 'this.route("tree", { path: "/test/:treeId"});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Use snake case in dynamic segments of routes',
+      }],
+    },
+    {
+      code: 'this.route("tree", { path: "/test/treeId/:treeChildId"});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Use snake case in dynamic segments of routes',
+      }],
+    },
+    {
+      code: 'this.route("tree", { path: "/test/tree-id/:tree-child-id"});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Use snake case in dynamic segments of routes',


### PR DESCRIPTION
Refactor `routes-segments-snake-case` rule logic to support checking route paths with multiple dynamic segments. 

Connected with issue no. https://github.com/netguru/eslint-plugin-netguru-ember/issues/6