### PR TITLE
Add basic rule for avoid sate leakage in components

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,18 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
 * Components
   * **closure-actions** - Always use closure actions [(more)](https://github.com/netguru/ember-styleguide#closure-actions)
   * **no-on-calls-in-components** - Don't use .on() in components [(more)](https://github.com/netguru/ember-styleguide#dont-use-on-calls-as-components-values)
+  * \* **avoid-leaking-state-in-components** - Don't use objects and arrays as default properties [(more)](https://github.com/netguru/ember-styleguide#avoid-leaking-state)
+
+    Example config:
+    ```
+    netguru-ember/avoid-leaking-state-in-components: [1, ['array', 'of', 'ignored', 'properties']]
+    ```
 
 
 * Routing
   * **routes-segments-snake-case** - Route's dynamic segments should use snake case [(more)](https://github.com/netguru/ember-styleguide#route-naming)
 
+\* Rule with optional settings
 
 ## Contribution guide
 

--- a/rules/avoid-leaking-state-in-components.js
+++ b/rules/avoid-leaking-state-in-components.js
@@ -8,44 +8,60 @@ var ember = require('./utils/ember');
 // (Don't use arrays or objects as default props)
 //------------------------------------------------------------------------------
 
-module.exports = function(context) {
-
-  var message = {
-    array: 'Avoid using arrays as default properties',
-    object: 'Avoid using objects as default properties',
-  };
-
-  var report = function(node, messageType) {
-    context.report(node, message[messageType]);
-  };
-
-  var ignoredProperties = [
-    'classNames',
-    'classNameBindings',
-    'actions',
-    'concatenatedProperties',
-    'mergedProperties',
-    'positionalParams',
-  ];
-
-  return {
-    CallExpression: function(node) {
-      if (!ember.isEmberComponent(node)) return;
-
-      var properties = ember.getModuleProperties(node);
-
-      properties
-        .filter(function(property) {
-          return ignoredProperties.indexOf(property.key.name) === -1;
-        })
-        .forEach(function(property) {
-          if (ember.isEmptyObjectProp(property)) {
-            report(property, 'object');
-          } else if (ember.isEmptyArrayProp(property)) {
-            report(property, 'array');
+module.exports = {
+  meta: {
+    schema: [
+      {
+        type: "object",
+        properties: {
+          exceptions: {
+              type: "array",
+              items: {type: "string"},
+              uniqueItems: true,
           }
-        });
-    }
-  };
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
 
+  create: function(context) {
+    var message = {
+      array: 'Avoid using arrays as default properties',
+      object: 'Avoid using objects as default properties',
+    };
+
+    var report = function(node, messageType) {
+      context.report(node, message[messageType]);
+    };
+
+    var ignoredProperties = [
+      'classNames',
+      'classNameBindings',
+      'actions',
+      'concatenatedProperties',
+      'mergedProperties',
+      'positionalParams',
+    ];
+
+    return {
+      CallExpression: function(node) {
+        if (!ember.isEmberComponent(node)) return;
+
+        var properties = ember.getModuleProperties(node);
+
+        properties
+          .filter(function(property) {
+            return ignoredProperties.indexOf(property.key.name) === -1;
+          })
+          .forEach(function(property) {
+            if (ember.isObjectProp(property)) {
+              report(property, 'object');
+            } else if (ember.isArrayProp(property)) {
+              report(property, 'array');
+            }
+          });
+      }
+    };
+  },
 };

--- a/rules/avoid-leaking-state-in-components.js
+++ b/rules/avoid-leaking-state-in-components.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var utils = require('./utils/utils');
+var ember = require('./utils/ember');
+
+//------------------------------------------------------------------------------
+// Components rule - Avoid leaking state
+// (Don't use arrays or objects as default props)
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+  var message = {
+    array: 'Avoid using arrays as default properties',
+    object: 'Avoid using objects as default properties',
+  };
+
+  var report = function(node, messageType) {
+    context.report(node, message[messageType]);
+  };
+
+  return {
+    CallExpression: function(node) {
+      if (!ember.isEmberComponent(node)) return;
+
+      var properties = ember.getModuleProperties(node);
+
+      properties.forEach(function(property) {
+        if (ember.isEmptyObjectProp(property)) {
+          report(property, 'object');
+        } else if (ember.isEmptyArrayProp(property)) {
+          report(property, 'array');
+        }
+      });
+    }
+  };
+
+};

--- a/rules/avoid-leaking-state-in-components.js
+++ b/rules/avoid-leaking-state-in-components.js
@@ -19,19 +19,32 @@ module.exports = function(context) {
     context.report(node, message[messageType]);
   };
 
+  var ignoredProperties = [
+    'classNames',
+    'classNameBindings',
+    'actions',
+    'concatenatedProperties',
+    'mergedProperties',
+    'positionalParams',
+  ];
+
   return {
     CallExpression: function(node) {
       if (!ember.isEmberComponent(node)) return;
 
       var properties = ember.getModuleProperties(node);
 
-      properties.forEach(function(property) {
-        if (ember.isEmptyObjectProp(property)) {
-          report(property, 'object');
-        } else if (ember.isEmptyArrayProp(property)) {
-          report(property, 'array');
-        }
-      });
+      properties
+        .filter(function(property) {
+          return ignoredProperties.indexOf(property.key.name) === -1;
+        })
+        .forEach(function(property) {
+          if (ember.isEmptyObjectProp(property)) {
+            report(property, 'object');
+          } else if (ember.isEmptyArrayProp(property)) {
+            report(property, 'array');
+          }
+        });
     }
   };
 

--- a/rules/avoid-leaking-state-in-components.js
+++ b/rules/avoid-leaking-state-in-components.js
@@ -10,22 +10,15 @@ var ember = require('./utils/ember');
 
 module.exports = {
   meta: {
-    schema: [
-      {
-        type: "object",
-        properties: {
-          exceptions: {
-              type: "array",
-              items: {type: "string"},
-              uniqueItems: true,
-          }
-        },
-        additionalProperties: false,
-      },
-    ],
+    schema: [{
+      type: "array",
+      items: { type: "string" },
+    }],
   },
 
   create: function(context) {
+    var ignoredProperties = context.options[0] || [];
+
     var message = {
       array: 'Avoid using arrays as default properties',
       object: 'Avoid using objects as default properties',
@@ -35,14 +28,14 @@ module.exports = {
       context.report(node, message[messageType]);
     };
 
-    var ignoredProperties = [
+    ignoredProperties = ignoredProperties.concat([
       'classNames',
       'classNameBindings',
       'actions',
       'concatenatedProperties',
       'mergedProperties',
       'positionalParams',
-    ];
+    ]);
 
     return {
       CallExpression: function(node) {

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -7,11 +7,10 @@ module.exports = {
   isEmberController: isEmberController,
   isInjectedServiceProp: isInjectedServiceProp,
   isObserverProp: isObserverProp,
-  isEmptyObjectProp: isEmptyObjectProp,
-  isEmptyArrayProp: isEmptyArrayProp,
+  isObjectProp: isObjectProp,
+  isArrayProp: isArrayProp,
   isComponentLifecycleHookName: isComponentLifecycleHookName,
   getModuleProperties: getModuleProperties,
-  // isEmberRoute: isEmberRoute,
 };
 
 // Private
@@ -73,22 +72,22 @@ function isObserverProp(node) {
   return isPropOfType(node, 'observer');
 }
 
-function isEmptyArrayProp(node) {
+function isArrayProp(node) {
   if (utils.isNewExpression(node.value)) {
     var parsedCallee = utils.parseCallee(node.value);
-    return parsedCallee.pop() === 'A' && !node.value.arguments.length;
+    return parsedCallee.pop() === 'A';
   }
 
-  return utils.isArrayExpression(node.value) && !node.value.elements.length;
+  return utils.isArrayExpression(node.value);
 }
 
-function isEmptyObjectProp(node) {
+function isObjectProp(node) {
   if (utils.isNewExpression(node.value)) {
     var parsedCallee = utils.parseCallee(node.value);
-    return parsedCallee.pop() === 'Object' && !node.value.arguments.length;
+    return parsedCallee.pop() === 'Object';
   }
 
-  return utils.isObjectExpression(node.value) && !node.value.properties.length;
+  return utils.isObjectExpression(node.value);
 }
 
 function isComponentLifecycleHookName(name) {
@@ -101,7 +100,3 @@ function isComponentLifecycleHookName(name) {
 function getModuleProperties(module) {
   return utils.findNodes(module.arguments, 'ObjectExpression')[0].properties;
 }
-
-// function isEmberRoute(node) {
-//   return isModule(node, 'Route');
-// }

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -7,6 +7,8 @@ module.exports = {
   isEmberController: isEmberController,
   isInjectedServiceProp: isInjectedServiceProp,
   isObserverProp: isObserverProp,
+  isEmptyObjectProp: isEmptyObjectProp,
+  isEmptyArrayProp: isEmptyArrayProp,
   isComponentLifecycleHookName: isComponentLifecycleHookName,
   getModuleProperties: getModuleProperties,
   // isEmberRoute: isEmberRoute,
@@ -69,6 +71,14 @@ function isInjectedServiceProp(node) {
 
 function isObserverProp(node) {
   return isPropOfType(node, 'observer');
+}
+
+function isEmptyArrayProp(node) {
+  return utils.isArrayExpression(node.value) && !node.value.elements.length;
+}
+
+function isEmptyObjectProp(node) {
+  return utils.isObjectExpression(node.value) && !node.value.properties.length;
 }
 
 function isComponentLifecycleHookName(name) {

--- a/rules/utils/ember.js
+++ b/rules/utils/ember.js
@@ -74,10 +74,20 @@ function isObserverProp(node) {
 }
 
 function isEmptyArrayProp(node) {
+  if (utils.isNewExpression(node.value)) {
+    var parsedCallee = utils.parseCallee(node.value);
+    return parsedCallee.pop() === 'A' && !node.value.arguments.length;
+  }
+
   return utils.isArrayExpression(node.value) && !node.value.elements.length;
 }
 
 function isEmptyObjectProp(node) {
+  if (utils.isNewExpression(node.value)) {
+    var parsedCallee = utils.parseCallee(node.value);
+    return parsedCallee.pop() === 'Object' && !node.value.arguments.length;
+  }
+
   return utils.isObjectExpression(node.value) && !node.value.properties.length;
 }
 

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -7,6 +7,7 @@ module.exports = {
   isObjectExpression: isObjectExpression,
   isArrayExpression: isArrayExpression,
   isFunctionExpression: isFunctionExpression,
+  isNewExpression: isNewExpression,
   isCallWithFunctionExpression: isCallWithFunctionExpression,
   isThisExpression: isThisExpression,
   getSize: getSize,
@@ -104,6 +105,16 @@ function isFunctionExpression(node) {
 }
 
 /**
+ * Check whether or not a node is an NewExpression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an NewExpression.
+ */
+function isNewExpression(node) {
+  return node !== undefined && node.type === 'NewExpression';
+}
+
+/**
  * Check whether or not a node is a CallExpression that has a FunctionExpression
  * as first argument, eg.:
  * tSomeAction: mysteriousFnc(function(){})
@@ -139,7 +150,7 @@ function getSize(node) {
 }
 
 /**
- * Parse CallExpression to get array of properties and object name
+ * Parse CallExpression or NewExpression to get array of properties and object name
  *
  * @param  {Object} node The node to parse
  * @return {Array} eg. ['Ember', 'computed', 'alias']
@@ -148,7 +159,7 @@ function parseCallee(node) {
   var parsedCallee = [];
   var callee;
 
-  if (isCallExpression(node)) {
+  if (isCallExpression(node) || isNewExpression(node)) {
     callee = node.callee;
 
     while (isMemberExpression(callee)) {

--- a/test/avoid-leaking-state-in-components.js
+++ b/test/avoid-leaking-state-in-components.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/avoid-leaking-state-in-components');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+eslintTester.run('avoid-leaking-state-in-components', rule, {
+  valid: [
+    {
+      code: 'export default Component.extend({someProp: "example", init() { this.set("anotherProp", []) } });',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    }
+  ],
+  invalid: [
+    {
+      code: 'export default Component.extend({someProp: []});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Avoid using arrays as default properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({someProp: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Avoid using objects as default properties',
+      }],
+    },
+  ]
+});

--- a/test/avoid-leaking-state-in-components.js
+++ b/test/avoid-leaking-state-in-components.js
@@ -15,9 +15,33 @@ var eslintTester = new RuleTester();
 eslintTester.run('avoid-leaking-state-in-components', rule, {
   valid: [
     {
-      code: 'export default Component.extend({someProp: "example", init() { this.set("anotherProp", []) } });',
+      code: 'export default Component.extend({ someProp: "example", init() { this.set("anotherProp", []) } });',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
-    }
+    },
+    {
+      code: 'export default Component.extend({ someProp: "example", init() { this.set("anotherProp", {}) } });',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({ someProp: "example", init() { this.set("anotherProp", new Ember.A()) } });',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({ someProp: "example", init() { this.set("anotherProp", new A()) } });',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({ someProp: "example", init() { this.set("anotherProp", new Ember.Object()) } });',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({ someProp: "example", init() { this.set("anotherProp", new Object()) } });',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({ classNames: [], classNameBindings: [], actions: {}, concatenatedProperties: [], mergedProperties: [], positionalParams: [] });',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
   ],
   invalid: [
     {
@@ -28,7 +52,35 @@ eslintTester.run('avoid-leaking-state-in-components', rule, {
       }],
     },
     {
+      code: 'export default Component.extend({someProp: new Ember.A()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Avoid using arrays as default properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({someProp: new A()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Avoid using arrays as default properties',
+      }],
+    },
+    {
       code: 'export default Component.extend({someProp: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Avoid using objects as default properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({someProp: new Ember.Object()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Avoid using objects as default properties',
+      }],
+    },
+    {
+      code: 'export default Component.extend({someProp: new Object()});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
       errors: [{
         message: 'Avoid using objects as default properties',


### PR DESCRIPTION
According to #8 and https://github.com/netguru/ember-styleguide#avoid-leaking-state

This PR adds a new rule `avoid-leaking-state-in-components`.

### Handled cases:

```
exampleProp: [],
exampleProp: {},
exampleProp: new Ember.A(),
exampleProp: new A(),
exampleProp: new Ember.Object(),
exampleProp: new Object(),
```

### Ignored properties:

- classNames
- classNameBindings
- actions
- concatenatedProperties
- mergedProperties
- positionalParams

### Possible configuration

I added possibility to configure rule, so that anyone can specify attributes that this rule should ignore extra.

Example configuration:

```
// .eslintrc
extends: netguru-ember
rules:
  netguru-ember/avoid-leaking-state-in-components: [1, ["rules", "validators"]]
```

This will additionally ignore `rules` and `validators` attributes.