### PR TITLE
New Rule - Do not use Ember function prototype extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
   * **no-side-effect** - Don't introduce side-effects in computed properties [(more)](https://github.com/netguru/ember-styleguide#dont-introduce-side-effects-in-computed-properties)
   * **jquery-ember-run** - Don’t use jQuery without Ember Run Loop [(more)](https://github.com/netguru/ember-styleguide#dont-use-jquery-without-ember-run-loop)
   * **named-functions-in-promises** - Use named functions defined on objects to handle promises [(more)](https://github.com/netguru/ember-styleguide#use-named-functions-defined-on-objects-to-handle-promises)
+  * **no-function-prototype-extensions** - Don't use Ember's function prototype extensions
 
 * Organizing
   * **order-in-components** - Organize your components [(more)](https://github.com/netguru/ember-styleguide#organize-your-components)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
   * **no-side-effect** - Don't introduce side-effects in computed properties [(more)](https://github.com/netguru/ember-styleguide#dont-introduce-side-effects-in-computed-properties)
   * **jquery-ember-run** - Don’t use jQuery without Ember Run Loop [(more)](https://github.com/netguru/ember-styleguide#dont-use-jquery-without-ember-run-loop)
   * **named-functions-in-promises** - Use named functions defined on objects to handle promises [(more)](https://github.com/netguru/ember-styleguide#use-named-functions-defined-on-objects-to-handle-promises)
-  * **no-function-prototype-extensions** - Don't use Ember's function prototype extensions
+  * **no-function-prototype-extensions** - Don't use Ember's function prototype extensions [(more)](https://github.com/netguru/ember-styleguide#do-not-use-embers-function-prototype-extensions)
 
 * Organizing
   * **order-in-components** - Organize your components [(more)](https://github.com/netguru/ember-styleguide#organize-your-components)

--- a/rules/no-function-prototype-extensions.js
+++ b/rules/no-function-prototype-extensions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var ember = require('./utils/ember');
 var utils = require('./utils/utils');
 
 //----------------------------------------------------------------------------------------------

--- a/rules/no-function-prototype-extensions.js
+++ b/rules/no-function-prototype-extensions.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var ember = require('./utils/ember');
+var utils = require('./utils/utils');
+
+//----------------------------------------------------------------------------------------------
+// General rule - Don't use Ember's function prototype extensions like .property() or .observe()
+//----------------------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+  var message = 'Don\'t use Ember\'s function prototype extensions';
+
+  var functionPrototypeExtensionNames = ['property', 'observe', 'on'];
+
+  var isFunctionPrototypeExtension = function (property) {
+    return utils.isIdentifier(property) && functionPrototypeExtensionNames.indexOf(property.name) !== -1;
+  };
+
+  var report = function(node) {
+    context.report(node, message);
+  };
+
+  return {
+    CallExpression: function(node) {
+      var callee = node.callee;
+
+      if (
+        utils.isCallExpression(node) &&
+        utils.isMemberExpression(callee) &&
+        utils.isFunctionExpression(callee.object) &&
+        isFunctionPrototypeExtension(callee.property)
+      ) {
+        report(node);
+      }
+    }
+  };
+};

--- a/test/no-function-prototype-extensions.js
+++ b/test/no-function-prototype-extensions.js
@@ -1,0 +1,93 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/no-function-prototype-extensions');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+eslintTester.run('no-function-prototype-extensions', rule, {
+  valid: [
+    {
+      code: 'export default Controller.extend({actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: function () {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({init() {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: computed("abc", function () {})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: observer("abc", function () {})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: service()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({actions: {test() {}}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({actions: {test: function () {}}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: function () {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: on("init", function () {})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: observer("abc", function () {abc.on();})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test: function () {$("body").on("click", abc);}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Controller.extend({test() {$("body").on("click", abc);}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+  ],
+  invalid: [
+    {
+      code: 'export default Controller.extend({test: function() {}.property("abc")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Don\'t use Ember\'s function prototype extensions',
+      }],
+    },
+    {
+      code: 'export default Controller.extend({test: function() {}.observe("abc")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Don\'t use Ember\'s function prototype extensions',
+      }],
+    },
+    {
+      code: 'export default Controller.extend({test: function() {}.on("init")});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Don\'t use Ember\'s function prototype extensions',
+      }],
+    }
+  ]
+});

--- a/test/no-function-prototype-extensions.js
+++ b/test/no-function-prototype-extensions.js
@@ -66,6 +66,10 @@ eslintTester.run('no-function-prototype-extensions', rule, {
       code: 'export default Controller.extend({test() {$("body").on("click", abc);}});',
       parserOptions: {ecmaVersion: 6, sourceType: "module"},
     },
+    {
+      code: 'export default Controller.extend({test() {$("body").on("click", abc).on("click", function () {});}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Adding new rule proposed here: https://github.com/netguru/eslint-plugin-netguru-ember/issues/9

Prevents form using Ember function prototype extensions like:

- `function() {}.property('abc')`
- `function() {}.observe('abc')`
- `function() {}.on('init')`

PR to style guide: https://github.com/netguru/ember-styleguide/pull/10

TODOs:
- [x] add link to the new rule in style guide to the README.md ones the PR to style guide got merged 
