### PR TITLE
No on calls in components

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
 
 * Components
   * **closure-actions** - Always use closure actions [(more)](https://github.com/netguru/ember-styleguide#closure-actions)
+  * **no-on-calls-in-components** - Don't use .on() in components
+
 
 * Routing
   * **routes-segments-snake-case** - Route's dynamic segments should use snake case [(more)](https://github.com/netguru/ember-styleguide#route-naming)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
 
 * Components
   * **closure-actions** - Always use closure actions [(more)](https://github.com/netguru/ember-styleguide#closure-actions)
-  * **no-on-calls-in-components** - Don't use .on() in components
+  * **no-on-calls-in-components** - Don't use .on() in components [(more)](https://github.com/netguru/ember-styleguide#dont-use-on-calls-as-components-values)
 
 
 * Routing

--- a/rules/no-on-calls-in-components.js
+++ b/rules/no-on-calls-in-components.js
@@ -30,7 +30,7 @@ module.exports = function(context) {
 
       var propertiesWithOnCalls = ember.getModuleProperties(node).filter(isOnCall);
 
-      if(propertiesWithOnCalls.length) {
+      if (propertiesWithOnCalls.length) {
         report(node);
       }
     }

--- a/rules/no-on-calls-in-components.js
+++ b/rules/no-on-calls-in-components.js
@@ -16,8 +16,12 @@ module.exports = function(context) {
     var callee = value.callee;
 
     return utils.isCallExpression(value) &&
-      utils.isIdentifier(callee) &&
-      callee.name === 'on';
+      (utils.isIdentifier(callee) && callee.name === 'on') ||
+      (
+        utils.isMemberExpression(callee) &&
+        utils.isIdentifier(callee.object) && callee.object.name === 'Ember' &&
+        utils.isIdentifier(callee.property) && callee.property.name === 'on'
+      );
   };
 
   var report = function(node) {

--- a/rules/no-on-calls-in-components.js
+++ b/rules/no-on-calls-in-components.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var ember = require('./utils/ember');
+var utils = require('./utils/utils');
+
+//----------------------------------------------
+// General rule - Don\'t use .on() in components
+//----------------------------------------------
+
+module.exports = function(context) {
+
+  var message = 'Don\'t use .on() in components';
+
+  var isOnCall = function (node) {
+    var value = node.value;
+    var callee = value.callee;
+
+    return utils.isCallExpression(value) &&
+      utils.isIdentifier(callee) &&
+      callee.name === 'on';
+  };
+
+  var report = function(node) {
+    context.report(node, message);
+  };
+
+  return {
+    CallExpression: function(node) {
+      if (!ember.isEmberComponent(node)) return;
+
+      var propertiesWithOnCalls = ember.getModuleProperties(node).filter(isOnCall);
+
+      if(propertiesWithOnCalls.length) {
+        report(node);
+      }
+    }
+  };
+};

--- a/test/no-on-calls-in-components.js
+++ b/test/no-on-calls-in-components.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/no-on-calls-in-components');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+eslintTester.run('no-on-calls-in-components', rule, {
+  valid: [
+    {
+      code: 'export default Component.extend({actions: {}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: service()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: inject.service()});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: false});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({classNames: ["abc", "def"]});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: computed(function () {})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: observer("abc", function () {})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: observer("abc", function () {test.on("xyz", def)})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc: function () {test.on("xyz", def)}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({abc() {$("body").on("click", def)}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({didInsertElement() {$("body").on("click", def).on("click", function () {})}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({actions: {abc() {test.on("xyz", def)}}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+    {
+      code: 'export default Component.extend({actions: {abc() {$("body").on("click", def).on("click", function () {})}}});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+    },
+  ],
+  invalid: [
+    {
+      code: 'export default Component.extend({test: on("didInsertElement", function () {})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Don\'t use .on() in components',
+      }],
+    },
+  ]
+});

--- a/test/no-on-calls-in-components.js
+++ b/test/no-on-calls-in-components.js
@@ -75,5 +75,12 @@ eslintTester.run('no-on-calls-in-components', rule, {
         message: 'Don\'t use .on() in components',
       }],
     },
+    {
+      code: 'export default Component.extend({test: Ember.on("didInsertElement", function () {})});',
+      parserOptions: {ecmaVersion: 6, sourceType: "module"},
+      errors: [{
+        message: 'Don\'t use .on() in components',
+      }],
+    },
   ]
 });


### PR DESCRIPTION
Adding new rule proposed here:: https://github.com/netguru/eslint-plugin-netguru-ember/issues/11

Prevents form using `.on()` calls as property values of Ember components.

Example:
```js
export default Component.extend({
  // BAD
  abc: on('didInsertElement', function () { /* custom logic */ }),

  // GOOD
  didInsertElement() { /* custom logic */ }
});
```

PR with changes to style guide: https://github.com/netguru/ember-styleguide/pull/11

TODOs:
- [x] add link to style guide in README.md