### PR TITLE
Fix named-functions-in-promises rule to recognize only spec-compliant promise methods

### DIFF
--- a/rules/named-functions-in-promises.js
+++ b/rules/named-functions-in-promises.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
     context.report(node, message);
   };
 
-  var promisesMethods = ['then', 'catch', 'success'];
+  var promisesMethods = ['then', 'catch'];
 
   return {
     CallExpression: function(node) {

--- a/rules/named-functions-in-promises.js
+++ b/rules/named-functions-in-promises.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
     context.report(node, message);
   };
 
-  var promisesMethods = ['then', 'catch'];
+  var promisesMethods = ['then', 'catch', 'finally'];
 
   return {
     CallExpression: function(node) {

--- a/test/named-functions-in-promises.js
+++ b/test/named-functions-in-promises.js
@@ -17,11 +17,29 @@ eslintTester.run('named-functions-in-promises', rule, {
     {
       code: 'user.save().then(this._reloadUser.bind(this));',
       parserOptions: {ecmaVersion: 6},
+    }, {
+      code: 'user.save().catch(this._handleError.bind(this));',
+      parserOptions: {ecmaVersion: 6},
+    }, {
+      code: 'user.save().finally(this._finallyDo.bind(this));',
+      parserOptions: {ecmaVersion: 6},
     }
   ],
   invalid: [
     {
       code: 'user.save().then(() => {return user.reload();});',
+      parserOptions: {ecmaVersion: 6},
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().catch(() => {return error.handle();});',
+      parserOptions: {ecmaVersion: 6},
+      errors: [{
+        message: 'Use named functions defined on objects to handle promises',
+      }],
+    }, {
+      code: 'user.save().finally(() => {return finallyDo();});',
       parserOptions: {ecmaVersion: 6},
       errors: [{
         message: 'Use named functions defined on objects to handle promises',


### PR DESCRIPTION
Don't recognize `.success` method, which is not present in official Promise specification, nor in `RSVP` (the implementation that Ember.JS is using).

Add `.finally()` to the list (provided by `RSVP`).