### PR TITLE
Add rule use ember get and set

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
   * **jquery-ember-run** - Don’t use jQuery without Ember Run Loop [(more)](https://github.com/netguru/ember-styleguide#dont-use-jquery-without-ember-run-loop)
   * **named-functions-in-promises** - Use named functions defined on objects to handle promises [(more)](https://github.com/netguru/ember-styleguide#use-named-functions-defined-on-objects-to-handle-promises)
   * **no-function-prototype-extensions** - Don't use Ember's function prototype extensions [(more)](https://github.com/netguru/ember-styleguide#do-not-use-embers-function-prototype-extensions)
+  * **use ember get and set** - Use ember get/set [(more)](https://github.com/netguru/ember-styleguide#use-ember-get-and-set)
 
 * Organizing
   * **order-in-components** - Organize your components [(more)](https://github.com/netguru/ember-styleguide#organize-your-components)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
   * **jquery-ember-run** - Don’t use jQuery without Ember Run Loop [(more)](https://github.com/netguru/ember-styleguide#dont-use-jquery-without-ember-run-loop)
   * **named-functions-in-promises** - Use named functions defined on objects to handle promises [(more)](https://github.com/netguru/ember-styleguide#use-named-functions-defined-on-objects-to-handle-promises)
   * **no-function-prototype-extensions** - Don't use Ember's function prototype extensions [(more)](https://github.com/netguru/ember-styleguide#do-not-use-embers-function-prototype-extensions)
-  * **use-ember-get-and-set** - Use Ember get/set [(more)](https://github.com/netguru/ember-styleguide#use-ember-get-and-set)
+  * **use-ember-get-and-set** - Use Ember get/set [(more)](https://github.com/netguru/ember-styleguide#use-emberget-and-emberset)
 
 * Organizing
   * **order-in-components** - Organize your components [(more)](https://github.com/netguru/ember-styleguide#organize-your-components)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All rules from our plugin have to be prefixed with `netguru-ember/`
   * **jquery-ember-run** - Don’t use jQuery without Ember Run Loop [(more)](https://github.com/netguru/ember-styleguide#dont-use-jquery-without-ember-run-loop)
   * **named-functions-in-promises** - Use named functions defined on objects to handle promises [(more)](https://github.com/netguru/ember-styleguide#use-named-functions-defined-on-objects-to-handle-promises)
   * **no-function-prototype-extensions** - Don't use Ember's function prototype extensions [(more)](https://github.com/netguru/ember-styleguide#do-not-use-embers-function-prototype-extensions)
-  * **use ember get and set** - Use ember get/set [(more)](https://github.com/netguru/ember-styleguide#use-ember-get-and-set)
+  * **use-ember-get-and-set** - Use Ember get/set [(more)](https://github.com/netguru/ember-styleguide#use-ember-get-and-set)
 
 * Organizing
   * **order-in-components** - Organize your components [(more)](https://github.com/netguru/ember-styleguide#organize-your-components)

--- a/rules/use-ember-get-and-set.js
+++ b/rules/use-ember-get-and-set.js
@@ -3,7 +3,7 @@
 var utils = require('./utils/utils');
 
 //------------------------------------------------------------------------------
-// Common - use get and set
+// General - use get and set
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {

--- a/rules/use-ember-get-and-set.js
+++ b/rules/use-ember-get-and-set.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
     context.report(node, message);
   };
 
-  var asd = [
+  var avoidedProperties = [
     'get',
     'set',
     'getProperties',
@@ -26,7 +26,7 @@ module.exports = function(context) {
     MemberExpression: function(node) {
       if (
         utils.isIdentifier(node.property) &&
-        asd.indexOf(node.property.name) > -1
+        avoidedProperties.indexOf(node.property.name) > -1
       ) {
         report(node.property);
       }

--- a/rules/use-ember-get-and-set.js
+++ b/rules/use-ember-get-and-set.js
@@ -19,7 +19,6 @@ module.exports = function(context) {
     'set',
     'getProperties',
     'setProperties',
-    'toggleProperty',
   ];
 
   return {

--- a/rules/use-ember-get-and-set.js
+++ b/rules/use-ember-get-and-set.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var utils = require('./utils/utils');
+
+//------------------------------------------------------------------------------
+// Common - use get and set
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+  var message = 'Use get/set';
+
+  var report = function(node) {
+    context.report(node, message);
+  };
+
+  var asd = [
+    'get',
+    'set',
+    'getProperties',
+    'setProperties',
+    'toggleProperty',
+  ];
+
+  return {
+    MemberExpression: function(node) {
+      if (
+        utils.isIdentifier(node.property) &&
+        asd.indexOf(node.property.name) > -1
+      ) {
+        report(node.property);
+      }
+    }
+  };
+
+};

--- a/rules/use-ember-get-and-set.js
+++ b/rules/use-ember-get-and-set.js
@@ -19,6 +19,7 @@ module.exports = function(context) {
     'set',
     'getProperties',
     'setProperties',
+    'getWithDefault',
   ];
 
   return {

--- a/test/use-ember-get-and-set.js
+++ b/test/use-ember-get-and-set.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/use-ember-get-and-set');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+eslintTester.run('use-ember-get-and-set', rule, {
+  valid: [
+    'get(this, "test")',
+    'get(controller, "test")',
+    'set(this, "test")',
+    'set(controller, "test")',
+    'getProperties(this, name, email, password)',
+    'getProperties(controller, name, email, password)',
+    'setProperties(this, {name: "Jon", email: "jon@snow.com"})',
+    'setProperties(controller, {name: "Jon", email: "jon@snow.com"})',
+    'toggleProperty(this, "test")',
+    'toggleProperty(controller, "test")',
+  ],
+  invalid: [
+    {
+      code: 'this.get("test")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'controller.get("test")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'model.get("test")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'this.set("test", "value")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'controller.set("test", "value")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'model.set("test", "value")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'this.getProperties("test", "test2")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'controller.getProperties("test", "test2")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'model.getProperties("test", "test2")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'this.setProperties({test: "value"})',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'controller.setProperties({test: "value"})',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'model.setProperties({test: "value"})',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'this.toggleProperty("test")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'controller.toggleProperty("test")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'model.toggleProperty("test")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+  ]
+});

--- a/test/use-ember-get-and-set.js
+++ b/test/use-ember-get-and-set.js
@@ -22,8 +22,6 @@ eslintTester.run('use-ember-get-and-set', rule, {
     'getProperties(controller, name, email, password)',
     'setProperties(this, {name: "Jon", email: "jon@snow.com"})',
     'setProperties(controller, {name: "Jon", email: "jon@snow.com"})',
-    'toggleProperty(this, "test")',
-    'toggleProperty(controller, "test")',
   ],
   invalid: [
     {
@@ -94,24 +92,6 @@ eslintTester.run('use-ember-get-and-set', rule, {
     },
     {
       code: 'model.setProperties({test: "value"})',
-      errors: [{
-        message: 'Use get/set',
-      }],
-    },
-    {
-      code: 'this.toggleProperty("test")',
-      errors: [{
-        message: 'Use get/set',
-      }],
-    },
-    {
-      code: 'controller.toggleProperty("test")',
-      errors: [{
-        message: 'Use get/set',
-      }],
-    },
-    {
-      code: 'model.toggleProperty("test")',
       errors: [{
         message: 'Use get/set',
       }],

--- a/test/use-ember-get-and-set.js
+++ b/test/use-ember-get-and-set.js
@@ -22,6 +22,8 @@ eslintTester.run('use-ember-get-and-set', rule, {
     'getProperties(controller, name, email, password)',
     'setProperties(this, {name: "Jon", email: "jon@snow.com"})',
     'setProperties(controller, {name: "Jon", email: "jon@snow.com"})',
+    'getWithDefault(this, "test", "default")',
+    'getWithDefault(controller, "test", "default")',
   ],
   invalid: [
     {
@@ -38,6 +40,18 @@ eslintTester.run('use-ember-get-and-set', rule, {
     },
     {
       code: 'model.get("test")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'this.getWithDefault("test", "default")',
+      errors: [{
+        message: 'Use get/set',
+      }],
+    },
+    {
+      code: 'controller.getWithDefault("test", "default")',
       errors: [{
         message: 'Use get/set',
       }],


### PR DESCRIPTION
We're expanding out styleguide with new rules. This PR adds implementation for one of them.

Use ember `get` and `set`:
```
// Good
get(this, 'test');
set(this, 'test', 'value');
getProperties(this, 'test', 'test2');
setProperties(this, { test: value });

// Bad
this.get('test');
this.set('test', 'value');
this.getProperties('test', 'test2');
this.setProperties({ test: value });
```