### PR TITLE
Add "String" as allowed property

### DIFF
--- a/rules/local-modules.js
+++ b/rules/local-modules.js
@@ -15,7 +15,7 @@ module.exports = function(context) {
     context.report(node, msg);
   };
 
-  var allowedEmberProperties = ['$', 'Object', 'Router'];
+  var allowedEmberProperties = ['$', 'Object', 'Router', 'String'];
   var allowedDSProperties = [];
 
   var isExpressionForbidden = function (objectName, node, allowedProperties) {


### PR DESCRIPTION
Overriding standard, built-in objects could lead to some issues which can be hard to debug. We should avoid overriding native objects, so `String` should be allowed property to use as `Ember.String` instead of local version.